### PR TITLE
Lazy initialize the emoji pattern

### DIFF
--- a/lib/src/main/java/net/fellbaum/jemoji/EmojiManager.java
+++ b/lib/src/main/java/net/fellbaum/jemoji/EmojiManager.java
@@ -24,7 +24,7 @@ public final class EmojiManager {
     private static final Map<Integer, List<Emoji>> EMOJI_FIRST_CODEPOINT_TO_EMOJIS_ORDER_CODEPOINT_LENGTH_DESCENDING;
     private static final List<Emoji> EMOJIS_LENGTH_DESCENDING;
 
-    private static final Pattern EMOJI_PATTERN;
+    private static Pattern EMOJI_PATTERN;
     private static final Pattern NOT_WANTED_EMOJI_CHARACTERS = Pattern.compile("[\\p{Alpha}\\p{Z}]");
 
     private static final Comparator<Emoji> EMOJI_CODEPOINT_COMPARATOR = (final Emoji o1, final Emoji o2) -> {
@@ -45,9 +45,6 @@ public final class EmojiManager {
             EMOJIS_LENGTH_DESCENDING = Collections.unmodifiableList(emojis.stream().sorted(EMOJI_CODEPOINT_COMPARATOR).collect(Collectors.toList()));
 
             EMOJI_FIRST_CODEPOINT_TO_EMOJIS_ORDER_CODEPOINT_LENGTH_DESCENDING = emojis.stream().collect(getEmojiLinkedHashMapCollector());
-
-            EMOJI_PATTERN = Pattern.compile(EMOJIS_LENGTH_DESCENDING.stream()
-                    .map(s -> "(" + Pattern.quote(s.getEmoji()) + ")").collect(Collectors.joining("|")));
         } catch (final JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -223,6 +220,11 @@ public final class EmojiManager {
      * @return The pattern for all emojis.
      */
     public static Pattern getEmojiPattern() {
+        if (EMOJI_PATTERN == null) {
+            EMOJI_PATTERN = Pattern.compile(EMOJIS_LENGTH_DESCENDING.stream()
+                    .map(s -> "(" + Pattern.quote(s.getEmoji()) + ")").collect(Collectors.joining("|")));
+        }
+
         return EMOJI_PATTERN;
     }
 


### PR DESCRIPTION
I feel like this pattern won't be used by many users, and thus it would give a small benefit to not initialize it until the user requests it

Also, while it doesn't take *too* long to construct the pattern, it does consume 649KB of memory, as seen on VisualVM
![image](https://github.com/felldo/JEmoji/assets/41875020/1ab62015-77b2-4ae5-91cc-87e608b6bafb)
