### PR TITLE
Use the exact name of the project in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,5 +13,5 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
 }
 
-rootProject.name = "jemoji"
+rootProject.name = "JEmoji"
 include("lib")


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/IDEA-317606/Changing-only-the-case-of-the-Gradle-root-project-name-causes-exception-while-importing-project-java.lang.IllegalStateException