### PR TITLE
Fixed bug when jemoji is included via module-info.java

### DIFF
--- a/lib/src/main/java/net/fellbaum/jemoji/EmojiManager.java
+++ b/lib/src/main/java/net/fellbaum/jemoji/EmojiManager.java
@@ -20,7 +20,7 @@ import static net.fellbaum.jemoji.InternalEmojiUtils.*;
 @SuppressWarnings("unused")
 public final class EmojiManager {
 
-    private static final String PATH = "emoji_sources/emojis.json";
+    private static final String PATH = "/emoji_sources/emojis.json";
 
     private static final Map<String, Emoji> EMOJI_UNICODE_TO_EMOJI;
     private static final Map<Integer, List<Emoji>> EMOJI_FIRST_CODEPOINT_TO_EMOJIS_ORDER_CODEPOINT_LENGTH_DESCENDING;
@@ -64,8 +64,7 @@ public final class EmojiManager {
 
     private static String readFileAsString() {
         try {
-            final ClassLoader classLoader = EmojiManager.class.getClassLoader();
-            try (final InputStream is = classLoader.getResourceAsStream(PATH)) {
+	    try (final InputStream is = EmojiManager.class.getResourceAsStream(PATH)) {
                 if (is == null) return null;
                 try (final InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
                      final BufferedReader reader = new BufferedReader(isr)) {


### PR DESCRIPTION
Dear felldo,
first of all, let me say that this is really a great library! It is exactly what I was looking for.
It tried to include JEmoji into my java project where I use module-info.java. However, several functions such as `EmojiManager.getAllEmojis()` throw an exception (see below). [emojitest.tar.gz](https://github.com/felldo/JEmoji/files/13878613/emojitest.tar.gz) contains an example project which will reproduce the error .
The reason is that `readFileAsString` cannot load the ressource-path _PATH_ by means of `classLoader.getResourceAsStream(PATH)`. According to [stackeroverflow.com](https://stackoverflow.com/questions/68314700/why-java-cannot-read-same-resource-file-when-module-info-is-added) one should use `EmojiManager.class.getResourceAsStream(PATH)` instead. This is the content of the PR.

It would be great if you could merge my PR.

Best regards,

Michael



Error message:
------------------------------------------snip------------------------------------------
Exception in thread "main" java.lang.ExceptionInInitializerError
	at test/test.Program.main(Program.java:11)
Caused by: java.lang.IllegalArgumentException: argument "content" is null
	at com.fasterxml.jackson.databind@2.16.0/com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:5054)
	at com.fasterxml.jackson.databind@2.16.0/com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3828)
	at net.fellbaum.jemoji/net.fellbaum.jemoji.EmojiManager.<clinit>(EmojiManager.java:38)
	... 1 more
------------------------------------------snap------------------------------------------